### PR TITLE
Show credentials link on plugin install page

### DIFF
--- a/lang/en/quizaccess_autoproctor.php
+++ b/lang/en/quizaccess_autoproctor.php
@@ -30,7 +30,7 @@ $string['pluginname'] = 'AutoProctor Integration';
 // Client credentials
 $string['credentials_info'] = 'Don\'t have credentials yet? <a href="https://www.autoproctor.co/developers/register/" target="_blank">Get your Client ID and Secret here</a>.';
 $string['client_id'] = 'AutoProctor Client ID';
-$string['client_id_desc'] = 'Enter your AutoProctor Client ID. Don\'t have credentials yet? <a href="https://www.autoproctor.co/developers/register/" target="_blank">Get your Client ID and Secret here</a>.';
+$string['client_id_desc'] = 'Enter your AutoProctor Client ID.';
 $string['client_secret'] = 'AutoProctor Client Secret';
 $string['client_secret_desc'] = 'Enter your AutoProctor Client Secret.';
 

--- a/lang/en/quizaccess_autoproctor.php
+++ b/lang/en/quizaccess_autoproctor.php
@@ -30,7 +30,7 @@ $string['pluginname'] = 'AutoProctor Integration';
 // Client credentials
 $string['credentials_info'] = 'Don\'t have credentials yet? <a href="https://www.autoproctor.co/developers/register/" target="_blank">Get your Client ID and Secret here</a>.';
 $string['client_id'] = 'AutoProctor Client ID';
-$string['client_id_desc'] = 'Enter your AutoProctor Client ID.';
+$string['client_id_desc'] = 'Enter your AutoProctor Client ID. Don\'t have credentials yet? <a href="https://www.autoproctor.co/developers/register/" target="_blank">Get your Client ID and Secret here</a>.';
 $string['client_secret'] = 'AutoProctor Client Secret';
 $string['client_secret_desc'] = 'Enter your AutoProctor Client Secret.';
 

--- a/settings.php
+++ b/settings.php
@@ -28,8 +28,8 @@ if ($hassiteconfig) {
     $settings = new admin_settingpage('quizaccess_autoproctor', get_string('pluginname', 'quizaccess_autoproctor'));
     $ADMIN->add('modsettings', $settings);
 
-    // Credentials info heading
-    $settings->add(new admin_setting_heading(
+    // Credentials info - using admin_setting_description so it renders on upgradesettings.php too.
+    $settings->add(new admin_setting_description(
         'quizaccess_autoproctor/credentials_info',
         '',
         get_string('credentials_info', 'quizaccess_autoproctor')

--- a/settings.php
+++ b/settings.php
@@ -24,14 +24,46 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+/**
+ * Info-only setting that renders on the upgrade settings page.
+ *
+ * Moodle's upgradesettings.php only shows settings where get_setting() returns null.
+ * admin_setting_heading and admin_setting_description always return true, so they
+ * are filtered out. This class returns null until the settings are first saved,
+ * allowing the info text to appear during initial plugin installation.
+ */
+class quizaccess_autoproctor_setting_info extends admin_setting {
+    public function __construct($name, $description) {
+        parent::__construct($name, '', $description, '');
+    }
+
+    public function get_setting() {
+        return $this->config_read($this->name);
+    }
+
+    public function get_defaultsetting() {
+        return '';
+    }
+
+    public function write_setting($data) {
+        $this->config_write($this->name, '1');
+        return '';
+    }
+
+    public function output_html($data, $query = '') {
+        $html = '<div>' . $this->description . '</div>';
+        $html .= '<input type="hidden" name="' . $this->get_full_name() . '" value="1" />';
+        return format_admin_setting($this, '', $html, '', true, '', null, $query);
+    }
+}
+
 if ($hassiteconfig) {
     $settings = new admin_settingpage('quizaccess_autoproctor', get_string('pluginname', 'quizaccess_autoproctor'));
     $ADMIN->add('modsettings', $settings);
 
-    // Credentials info - using admin_setting_description so it renders on upgradesettings.php too.
-    $settings->add(new admin_setting_description(
+    // Credentials info - custom class so it renders on upgradesettings.php during first install.
+    $settings->add(new quizaccess_autoproctor_setting_info(
         'quizaccess_autoproctor/credentials_info',
-        '',
         get_string('credentials_info', 'quizaccess_autoproctor')
     ));
 

--- a/settings.php
+++ b/settings.php
@@ -52,9 +52,14 @@ class quizaccess_autoproctor_setting_info extends admin_setting {
     }
 
     public function output_html($data, $query = '') {
-        $html = '<div>' . $this->description . '</div>';
+        $html = '<div class="form-item row" id="admin-' . $this->name . '">';
+        $html .= '<div class="form-label col-sm-3"></div>';
+        $html .= '<div class="form-setting col-sm-9">';
+        $html .= '<div class="form-description mt-3 mb-3">' . highlight($query, $this->description) . '</div>';
         $html .= '<input type="hidden" name="' . $this->get_full_name() . '" value="1" />';
-        return format_admin_setting($this, '', $html, '', true, '', null, $query);
+        $html .= '</div>';
+        $html .= '</div>';
+        return $html;
     }
 }
 }

--- a/settings.php
+++ b/settings.php
@@ -32,6 +32,7 @@ defined('MOODLE_INTERNAL') || die();
  * are filtered out. This class returns null until the settings are first saved,
  * allowing the info text to appear during initial plugin installation.
  */
+if (!class_exists('quizaccess_autoproctor_setting_info')) {
 class quizaccess_autoproctor_setting_info extends admin_setting {
     public function __construct($name, $description) {
         parent::__construct($name, '', $description, '');
@@ -55,6 +56,7 @@ class quizaccess_autoproctor_setting_info extends admin_setting {
         $html .= '<input type="hidden" name="' . $this->get_full_name() . '" value="1" />';
         return format_admin_setting($this, '', $html, '', true, '', null, $query);
     }
+}
 }
 
 if ($hassiteconfig) {


### PR DESCRIPTION
## Summary
- Adds a custom `admin_setting` subclass so the "Get your Client ID and Secret" link renders on Moodle's `upgradesettings.php` page during first-time plugin installation
- Moodle's upgrade page only shows settings where `get_setting()` returns `null` — the built-in `admin_setting_heading` and `admin_setting_description` always return `true` and are filtered out
- Uses proper col-sm-3/col-sm-9 grid layout to align with other settings

## Test plan
- [ ] Install the plugin fresh on a Moodle instance
- [ ] Verify the "Get your Client ID and Secret here" link appears on the upgrade settings page
- [ ] Verify the link also still appears on the regular plugin settings page
- [ ] Click "Save changes" on the upgrade page and verify the link doesn't reappear as a "new setting" on subsequent upgrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)